### PR TITLE
CaptureRectToImage - opmitized memory usage

### DIFF
--- a/screenshot.go
+++ b/screenshot.go
@@ -16,3 +16,7 @@ func CaptureDisplay(displayIndex int) (*image.RGBA, error) {
 func CaptureRect(rect image.Rectangle) (*image.RGBA, error) {
 	return Capture(rect.Min.X, rect.Min.Y, rect.Dx(), rect.Dy())
 }
+
+func CaptureRectToImage(rect image.Rectangle, img *image.RGBA) error {
+	return CaptureToImage(rect.Min.X, rect.Min.Y, rect.Dx(), rect.Dy(), img)
+}

--- a/screenshot_windows.go
+++ b/screenshot_windows.go
@@ -18,7 +18,10 @@ func capture(x, y, width, height int, img *image.RGBA) error {
 		return errors.New("capture to nil img")
 	}
 	rect := image.Rect(0, 0, width, height)
-	if !img.Rect.Eq(rect) {
+
+	if img.Rect.Empty() {
+		img.Rect = rect
+	} else if !img.Rect.Eq(rect) {
 		return errors.New("capture to img that != width/height")
 	}
 


### PR DESCRIPTION
Hello.
There is a way to optimize memory using when taking screenshots frequently: to reuse image.RGBA object, not to create new every capturing.

As all pixels will be rewritten we can use the same object more and more.
Image's rect must be the same as capture's rect.

This optimization makes sense for me and works only for Windows. If this is will be interesting for others - it can be extended for other platforms and merged.

Backward compatible API.